### PR TITLE
Implement “Remember me” feature of login page.

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,7 +18,7 @@ import Welcome from './pages/Welcome'
 export default function App() {
   const [loggedIn, setLoggedIn] = useState(localStorage.getItem('token') ? true : false)
 
-  const handleLogin = useCallback((email, password) => {
+  const handleLogin = useCallback((email, password, rememberMe) => {
     fetch('/token-auth/', {
       method: 'POST',
       headers: {
@@ -32,6 +32,7 @@ export default function App() {
       .then(res => res.json())
       .then(json => {
         localStorage.setItem('token', json.token)
+        localStorage.setItem('rememberMe', rememberMe)
         JSON.stringify(json.token) ? setLoggedIn(true) : setLoggedIn(false)
       },
         (error) => {

--- a/frontend/src/components/checkboxfield.js
+++ b/frontend/src/components/checkboxfield.js
@@ -2,9 +2,9 @@
 import React from 'react'
 import { Checkbox } from 'react-bulma-components/lib/components/form'
 
-const CheckboxField = ({ text }) => (
+const CheckboxField = ({ text, onChange }) => (
     <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
-      <Checkbox style={{ marginRight: '10px' }}/>
+      <Checkbox style={{ marginRight: '10px' }} onClick={onChange}/>
       <p>{text}</p>
     </div>
 )

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -27,14 +27,19 @@ export default function Login(props) {
 
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
+    const [rememberMe, setRememberMe] = useState(false)
 
     let history = useHistory()
     useEffect(() => {
-        if(props.logged_in) {
+        if((localStorage.getItem('token') != null) || props.logged_in) {
             history.push('/my-communities')
         }
-    
     })
+
+    function handleRememberMe() {
+        setRememberMe(!rememberMe)
+    }
+
     return (
         <Container style={containerStyle}>
             <Heading size={4}>Log in to Here to Serve</Heading>
@@ -48,9 +53,9 @@ export default function Login(props) {
                 <Input value ={password} type="password" placeholder="Password" onChange={e => setPassword(e.target.value)}/>
             </Field>
             <Field>
-                <CheckboxField text={"Remember me"}/>
+                <CheckboxField text={"Remember me"} onChange={handleRememberMe}/>
             </Field>
-            <Button style={{marginBottom: "1rem"}} color="primary" fullwidth={true} onClick={() => props.handle_login(email, password)}>LOGIN</Button>
+            <Button style={{marginBottom: "1rem"}} color="primary" fullwidth={true} onClick={() => props.handle_login(email, password, rememberMe)}>LOGIN</Button>
             <Notification style={notifStyle}>
                 <a href="#">Forgot Password?</a> or <Link to='/register'>Create Account</Link>
             </Notification>


### PR DESCRIPTION
Added a `rememberMe` boolean to `localStorage` (alongside the token).

If "remember me" is selected on the login page, `rememberMe` is set to true. 

On logout, we should delete a user's token only if `rememberMe` is false. 

On /login, if a token is present in `localStorage`, a user is assumed to be logged in and redirected to `/my-communities`